### PR TITLE
fix/fetch-genres-in-catalog

### DIFF
--- a/src/app/catalog/[category]/page.tsx
+++ b/src/app/catalog/[category]/page.tsx
@@ -4,7 +4,6 @@ import { AccentContainer } from "@/widgets/layout/ui/accentContainer";
 import FiltersBlock from "../components/filtersBlock/FiltersBlock";
 import Hero from "../components/hero/Hero";
 import GenericCatalogList from "../components/genericCatalogList/GenericCatalogList";
-import { getGenresKinds } from "@/api/genresKinds/genresKindsApi";
 import { getMerchKinds } from "@/api/merchKinds/merchKindsApi";
 import { Metadata } from "next";
 import s from "./page.module.scss";
@@ -42,14 +41,11 @@ const CategoryPage = async ({
     merchKinds = await getMerchKinds();
   }
 
-  const genresKinds = await getGenresKinds();
-
-
   return (
     <>
       <AccentContainer>
         <Hero />
-        <FiltersBlock сategory={category} basePath={`/catalog/${category}/`} genresList={genresKinds} merchList={merchKinds}/>
+        <FiltersBlock сategory={category} basePath={`/catalog/${category}/`} merchList={merchKinds}/>
       </AccentContainer>
       <Suspense fallback={<div className={s.message}>Загрузка карточек...</div>}>
         <GenericCatalogList 

--- a/src/app/catalog/components/filtersBlock/FilterBlock.type.ts
+++ b/src/app/catalog/components/filtersBlock/FilterBlock.type.ts
@@ -4,7 +4,7 @@ import { TMerchKind } from "@/api/merchKinds/merchKindsApi.types";
 export interface FilterBlockProps {
   сategory: string;
   basePath: string;
-  genresList: TGenreKind[];
+  //genresList: TGenreKind[];
   merchList?: TMerchKind[];
 }
 

--- a/src/app/catalog/components/filtersBlock/FiltersBlock.tsx
+++ b/src/app/catalog/components/filtersBlock/FiltersBlock.tsx
@@ -4,6 +4,7 @@ import s from "./FiltersBlock.module.scss";
 import { FilterBlockProps } from "./FilterBlock.type";
 import FiltersGroup from "./ui/filtersGroup/FiltersGroup";
 import { useRouter, useSearchParams } from "next/navigation";
+import { useFilters } from "../../provider/useFilters";
 
 const CATEGORIES = [
   {
@@ -39,9 +40,11 @@ const ORDERING = [
   },
 ];
 
-const FiltersBlock = ({ сategory, basePath, genresList, merchList }: FilterBlockProps) => {
+const FiltersBlock = ({ сategory, basePath, merchList }: FilterBlockProps) => {
 
   const router = useRouter();
+
+  const { genresList } = useFilters();
 
   const searchParams = useSearchParams();
   const currentFiltersByGenre = searchParams.getAll('genre');

--- a/src/app/catalog/layout.tsx
+++ b/src/app/catalog/layout.tsx
@@ -1,0 +1,18 @@
+import { getGenresKinds } from "@/api/genresKinds/genresKindsApi";
+import { Suspense } from "react";
+import { FiltersProvider } from "./provider/FiltersProvider";
+
+const CategoryLayout = async ({ children }: {children: React.ReactNode}) => {
+
+  const genresKinds = await getGenresKinds();
+
+  return (
+    <Suspense fallback={<div>Загрузка...</div>}>
+      <FiltersProvider genresList={genresKinds}>
+        {children}
+      </FiltersProvider>
+    </Suspense>
+  )
+};
+
+export default CategoryLayout;

--- a/src/app/catalog/provider/FiltersProvider.tsx
+++ b/src/app/catalog/provider/FiltersProvider.tsx
@@ -1,0 +1,29 @@
+'use client';
+
+import { TGenreKind } from "@/api/genresKinds/genresKindsApi.types";
+import { createContext } from "react";
+
+type FiltersContextType = {
+  genresList: TGenreKind[];
+};
+
+export const FiltersContext = createContext<FiltersContextType | undefined>(undefined);
+
+export function FiltersProvider ({ 
+  genresList, 
+  children 
+}: {
+  genresList: TGenreKind[],
+  children: React.ReactNode
+}) {
+
+  const value = {
+    genresList: genresList
+  };
+
+  return (
+    <FiltersContext.Provider value={value}>
+      {children}
+    </FiltersContext.Provider>
+  )
+};

--- a/src/app/catalog/provider/useFilters.ts
+++ b/src/app/catalog/provider/useFilters.ts
@@ -1,0 +1,14 @@
+"use client";
+
+import { useContext } from "react";
+import { FiltersContext } from "./FiltersProvider";
+
+export function useFilters() {
+  const context = useContext(FiltersContext);
+
+  if (context === undefined) {
+    throw new Error('useFilters must be used inside a FiltersProvider');
+  }
+
+  return context;
+};


### PR DESCRIPTION
После прошлого ревью по каталогу я исправила получение подкатегорий мерча по условию (только если выбрана катагория "мерч") в catalog/[category]/page.tsx. Получение жанров оставила без изменений, т.к они нужны для всех категорий.
Но потом поняла, что жанры запрашиваются каждый раз, когда пользователь меняет категорию, хотя они одинаковые для всех категорий. Поэтому решила создать layout в котором получаю эти жанры один раз, когда пользователь открывает каталог и сохраняю в контексте